### PR TITLE
Make the flex of the Pokemon independent of the flex of the footer

### DIFF
--- a/web/src/Paste.svelte
+++ b/web/src/Paste.svelte
@@ -195,8 +195,8 @@
 </head>
 
 <!--Wait for paste_data.sets to exist-->
-<div class="content-container">
-	<main>
+<div>
+	<main class="content-container">
 		{#if paste_data !== undefined && paste_data !== null}
 			{#each paste_data.sets as set_item}
 				{#if set_item.mon !== null}

--- a/web/src/paste.css
+++ b/web/src/paste.css
@@ -15,7 +15,7 @@ p {
 
 	.content-container {
 		display: flex;
-		flex-direction: column-reverse;
+		flex-direction: column;
 		/* side-content above main */
 	}
 
@@ -35,7 +35,8 @@ p {
 
 	.content-container {
 		display: flex;
-		flex-direction: column;
+		flex-direction: row;
+		flex-wrap: wrap;
 		/* main above side-content */
 	}
 


### PR DESCRIPTION
This will accomplish a couple of things:

- This will prevent the footer from jumping to the top when I split my browser window to half-width.
- This will let you more easily replicate Pokepaste's ability to turn on and off column mode (just change the `flex-direction` in `.content-container` from `row` to `column`).